### PR TITLE
Changes to make it easier to compare LevelDB with RocksDB:

### DIFF
--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -25,10 +25,10 @@ static const int kNumLevels = 7;
 static const int kL0_CompactionTrigger = 4;
 
 // Soft limit on number of level-0 files.  We slow down writes at this point.
-static const int kL0_SlowdownWritesTrigger = 8;
+static const int kL0_SlowdownWritesTrigger = 12;
 
 // Maximum number of level-0 files.  We stop writes at this point.
-static const int kL0_StopWritesTrigger = 12;
+static const int kL0_StopWritesTrigger = 20;
 
 // Maximum level to which a new compacted memtable is pushed if it
 // does not create overlap.  We try to push to level 2 to avoid the

--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -159,7 +159,7 @@ struct ReadOptions {
   const Snapshot* snapshot;
 
   ReadOptions()
-      : verify_checksums(false),
+      : verify_checksums(true),
         fill_cache(true),
         snapshot(NULL) {
   }

--- a/util/options.cc
+++ b/util/options.cc
@@ -19,7 +19,7 @@ Options::Options()
       write_buffer_size(4<<20),
       max_open_files(1000),
       block_cache(NULL),
-      block_size(4096),
+      block_size(16 * 1024),
       block_restart_interval(16),
       compression(kSnappyCompression),
       filter_policy(NULL) {


### PR DESCRIPTION
- add --seed option to db_bench so per-thread RNG seed can be changed per-run
- add --sync option to db_bench so WriteOptions::sync option can be set for most tests (fillsync ignores this)
- add --writes_per_second option to db_bench to rate limit write rate for readwhilewriting. Otherwise
  a fast writer can starve reads.
- change --cache_size from int to long to support cache sizes larger than 2G
- change ReadOptions::verify_checksum from false to true. Default for this really should be true.
- increase slowdown and stop triggers for #files in L0 from 8/12 to 12/20. These are configurable
  in RocksDB.
- change block_size from 4096 to 16384. This is configurable in RocksDB.

Summary:

Test Plan:

Reviewers:

CC:

Task ID: #

Blame Rev:
